### PR TITLE
Do not use spaces on the inside of object literal braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,5 +42,9 @@ module.exports = {
         ],
         'no-plusplus': 'off',
         'no-restricted-properties': 'off',
+        'object-curly-spacing': [
+            'error',
+            'never',
+        ],
     },
 };


### PR DESCRIPTION
Per [discussion on the Thorn repo](https://github.com/sugarcrm/thorn/pull/138/files#r102359921), we decided that having spaces on the inside of object literal braces is unappealing and a waste of space.